### PR TITLE
Fixes the response in case no examples are present for a response

### DIFF
--- a/lib/mimicry/open_api/example.ex
+++ b/lib/mimicry/open_api/example.ex
@@ -9,12 +9,15 @@ defmodule Mimicry.OpenAPI.Example do
   chooses an example based on the defined examples for the response and the spec (for references)
   """
   @spec choose(Response.t(), String.t() | :random, Specification.t()) ::
-          {:ok, map()} | {:error, :not_found}
+          {:ok, map()} | {:error, :not_found} | {:error, :no_examples}
   def choose(
         response,
         reference_or_random,
         spec \\ Specification.unsupported()
       )
+
+  def choose(%Response{examples: examples}, :random, _) when examples == %{},
+    do: {:error, :no_examples}
 
   def choose(
         _response = %Response{examples: examples},

--- a/lib/mimicry/open_api/example.ex
+++ b/lib/mimicry/open_api/example.ex
@@ -9,7 +9,7 @@ defmodule Mimicry.OpenAPI.Example do
   chooses an example based on the defined examples for the response and the spec (for references)
   """
   @spec choose(Response.t(), String.t() | :random, Specification.t()) ::
-          {:ok, map()} | {:error, :not_found} | {:error, :no_examples}
+          {:ok, map()} | {:error, :not_found | :no_examples}
   def choose(
         response,
         reference_or_random,

--- a/test/mimicry/mock_api_test.exs
+++ b/test/mimicry/mock_api_test.exs
@@ -11,7 +11,6 @@ defmodule Mimicry.MockAPITest do
     end
 
     @tag specification: "products-with-examples.yaml"
-    @tag :focus
     test "will pick a product from the examples by a matching identifier", %{
       conn: conn,
       specification: spec

--- a/test/mimicry/open_api/example_test.exs
+++ b/test/mimicry/open_api/example_test.exs
@@ -57,7 +57,6 @@ defmodule Mimicry.OpenAPI.ExampleTest do
     end
 
     @tag specification: "simple.yaml"
-    @tag :focus
     test "will return a random example", %{specification: spec} do
       response = %Response{examples: @examples}
       {:ok, %{"value" => _}} = response |> Example.choose(:random, spec)

--- a/test/mimicry/open_api/example_test.exs
+++ b/test/mimicry/open_api/example_test.exs
@@ -61,5 +61,11 @@ defmodule Mimicry.OpenAPI.ExampleTest do
       response = %Response{examples: @examples}
       {:ok, %{"value" => _}} = response |> Example.choose(:random, spec)
     end
+
+    test "will return an error if no examples are defined" do
+      response = %Response{examples: %{}}
+
+      {:error, :no_examples} = response |> Example.choose(:random, %{})
+    end
   end
 end


### PR DESCRIPTION
- removes even more focus
- falls back to a 501 error when no examples exist

:shrug:
