### PR TITLE
Shows available servers when requesting root

### DIFF
--- a/test/mimicry_api/controllers/proxy_controller_test.exs
+++ b/test/mimicry_api/controllers/proxy_controller_test.exs
@@ -13,6 +13,27 @@ defmodule MimicryApi.ProxyControllerTest do
     assert [Mimicry.version()] == conn |> get_resp_header("x-mimicry-version")
   end
 
+  test "GET / shows available hosts to pass", %{conn: conn} do
+    conn = conn |> get("/")
+    assert %{"available_hosts" => hosts} = conn |> json_response(:ok)
+    assert hosts == []
+  end
+
+  @tag server: "simple.yaml"
+  test "GET / shows available hosts when specs are running", %{conn: conn} do
+    conn = conn |> get("/")
+
+    assert %{
+             "available_hosts" => [
+               %{"url" => url, "title" => title, "version" => version}
+             ]
+           } = conn |> json_response(:ok)
+
+    assert url == "https://simple-api.testing.com"
+    assert title == "Test YAML"
+    assert version == "1.0"
+  end
+
   describe "when using \"x-mimicry-host\"" do
     @fake_host "https://foo.bar.com"
 

--- a/test/mimicry_api/controllers/server_controller_test.exs
+++ b/test/mimicry_api/controllers/server_controller_test.exs
@@ -3,7 +3,7 @@ defmodule MimicryApi.ServerControllerTest do
   use Mimicry.MockServerCase
 
   @tag server: "simple.yaml"
-  test "GET /", %{conn: conn} do
+  test "GET /__mimicry/", %{conn: conn} do
     conn = conn |> get(Routes.server_path(conn, :index))
     assert %{"servers" => servers} = conn |> json_response(:ok)
 


### PR DESCRIPTION
- corrects a path in test description
- shows available specs with their host info

Fixes #13 

### Before
```json 
{
    "message": "Use \"X-Mimicry-Host\" HTTP header to direct traffic to a registered API"
}
```
### After:
```json
{
    "available_hosts": [
        {
            "title": "Products",
            "url": "https://floriank-products.production.info",
            "version": "1.0"
        }
    ],
    "message": "Use \"X-Mimicry-Host\" HTTP header to direct traffic to a registered API"
}
```