### PR TITLE
Update base image to latest versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,11 @@ updates:
   schedule:
     interval: daily # default: 05:00 UTC
 
+- package-ecosystem: docker
+  directory: "/"
+  schedule:
+    interval: weekly # default: Monday 05:00 UTC
+
 - package-ecosystem: github-actions
   directory: "/"
   schedule:

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -15,8 +15,8 @@ jobs:
 
     strategy:
       matrix:
-        otp: [23]
-        elixir: ['1.11']
+        otp: [24, 23]
+        elixir: ['1.12', '1.11']
     steps:
     - uses: actions/checkout@v2
     - uses: actions/cache@v2.1.6

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM hexpm/elixir:1.11.4-erlang-24.0-alpine-3.13.3 as base
+FROM hexpm/elixir:1.12.2-erlang-24.0.3-alpine-3.14.0 as base
 
 RUN addgroup -g 1000 -S devgroup && adduser -u 1000 -S devuser -G devgroup
 USER devuser
@@ -45,4 +45,3 @@ RUN find /app -executable -type f -exec chmod +x {} +
 RUN mkdir /specifications
 
 CMD [ "/app/bin/mimicry", "start" ]
-


### PR DESCRIPTION
Updates to:
- Elixir 1.12.2
- Erlang 24.0.3
- Alpine 3.14

Also:
- Add dependabot rule for docker

I hope it is able to detect and ignore RCs and betas
despite the long tag names.