### PR TITLE
Explicitly clears servers

### DIFF
--- a/test/mimicry_api/controllers/proxy_controller_test.exs
+++ b/test/mimicry_api/controllers/proxy_controller_test.exs
@@ -13,7 +13,6 @@ defmodule MimicryApi.ProxyControllerTest do
     assert [Mimicry.version()] == conn |> get_resp_header("x-mimicry-version")
   end
 
-  @tag :reset_servers
   test "GET / shows available hosts to pass", %{conn: conn} do
     conn = conn |> get("/")
     assert %{"available_hosts" => hosts} = conn |> json_response(:ok)

--- a/test/mimicry_api/controllers/proxy_controller_test.exs
+++ b/test/mimicry_api/controllers/proxy_controller_test.exs
@@ -13,6 +13,7 @@ defmodule MimicryApi.ProxyControllerTest do
     assert [Mimicry.version()] == conn |> get_resp_header("x-mimicry-version")
   end
 
+  @tag :reset_servers
   test "GET / shows available hosts to pass", %{conn: conn} do
     conn = conn |> get("/")
     assert %{"available_hosts" => hosts} = conn |> json_response(:ok)

--- a/test/support/mock_server_case.ex
+++ b/test/support/mock_server_case.ex
@@ -42,19 +42,13 @@ defmodule Mimicry.MockServerCase do
 
   setup context do
     file_name = context |> Map.get(:server, false)
-    reset = context |> Map.get(:reset_servers, false)
 
     if file_name do
       :ok = clear_servers()
-      {:ok, server_pid} = add_server(file_name)
+      {:ok, _server_pid} = add_server(file_name)
 
-      on_exit(fn ->
-        MockServerList.delete_server(server_pid)
-      end)
-    end
-
-    if reset do
-      :ok = clear_servers()
+      # make sure server is cleared afterwards
+      on_exit(&clear_servers/0)
     end
 
     :ok

--- a/test/support/mock_server_case.ex
+++ b/test/support/mock_server_case.ex
@@ -42,6 +42,7 @@ defmodule Mimicry.MockServerCase do
 
   setup context do
     file_name = context |> Map.get(:server, false)
+    reset = context |> Map.get(:reset_servers, false)
 
     if file_name do
       :ok = clear_servers()
@@ -50,6 +51,10 @@ defmodule Mimicry.MockServerCase do
       on_exit(fn ->
         MockServerList.delete_server(server_pid)
       end)
+    end
+
+    if reset do
+      :ok = clear_servers()
     end
 
     :ok


### PR DESCRIPTION
Addresses #34.

Since test order is random, and servers were not cleared by default, this led to tests breaking randomly, depending on the order they were executed in.

Fixes #34 