### PR TITLE
Use latest and greatest for Erlang and Elixir

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -14,8 +14,8 @@ jobs:
 
     strategy:
       matrix:
-        otp: [24, 23]
-        elixir: ['1.12', '1.11']
+        otp: [25, 24]
+        elixir: ['1.14', '1.13']
     steps:
     - uses: actions/checkout@v3
     - uses: actions/cache@v3
@@ -65,8 +65,8 @@ jobs:
           ${{ runner.os }}-build-
     - uses: erlef/setup-beam@v1.14.0
       with:
-        otp-version: 23
-        elixir-version: 1.11
+        otp-version: 25
+        elixir-version: 1.14
 
     - name: Install inotify-tools
       run: sudo apt-get install inotify-tools


### PR DESCRIPTION
Note: ubuntu-22.04 only supports Erlang OTP 24.2 or newer for setup-beam GHA:
https://github.com/erlef/setup-beam#compatibility-between-operating-system-and-erlangotp